### PR TITLE
Move tape to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "test": "test"
   },
   "dependencies": {
-    "tape": "~1.0.4",
     "mout": "~0.6.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.6.2"
+    "grunt-contrib-jshint": "~0.6.2",
+    "tape": "~1.0.4"
   },
   "scripts": {
     "test": "node test/credential-test.js"


### PR DESCRIPTION
`tape` is not needed in production environment
