### PR TITLE
Proposed constant time string comparison re #12

### DIFF
--- a/constantTimeCompare.js
+++ b/constantTimeCompare.js
@@ -30,6 +30,7 @@ module.exports = function constantTimeCompare(a, b) {
   // Using with{} nixes some V8 optimizations that would otherwise undermine
   // our intentions here.
   with({}) {
+    // Add at least one character so that there's at least one thing to modulo over.
     a += " ";
     b += " ";
     var aLen = a.length,

--- a/constantTimeCompare.js
+++ b/constantTimeCompare.js
@@ -1,0 +1,46 @@
+  /**
+   * constantTimeCompare(x, y)
+   *
+   *  Created by Eric Elliott for the book,
+   *  Programming JavaScript Applications" (O'Reilly)
+   *
+   * MIT license http://opensource.org/licenses/MIT
+   */
+  
+// Regardless of the string size the number of character iterations/comparisons
+// ought to be equal to or higher than the maximum string size.
+var MAX_KEY_CHARS = 1024;
+
+  /*
+   * Compare two strings, x and y with a constant-time
+   * algorithm to prevent attacks based on timing statistics.
+   *
+   * This really ought to be in C; see:
+   *     https://github.com/joyent/node/issues/8560
+   *     http://stackoverflow.com/questions/18476402
+   *
+   * See also:
+   *     http://jsperf.com/constant-time-string-comparison
+   *     
+   * @param  {String} x
+   * @param  {String} y
+   * @return {Boolean}
+   */
+module.exports = function constantTimeCompare(a, b) {
+  // Using with{} nixes some V8 optimizations that would otherwise undermine
+  // our intentions here.
+  with({}) {
+    a += " ";
+    b += " ";
+    var aLen = a.length,
+        bLen = b.length,
+        match = aLen === bLen ? 1 : 0,
+        i = Math.max(aLen, bLen, MAX_KEY_CHARS);
+    while (i--) {
+      // We repeat the comparison over the strings with % so that we do not compare
+      // a number to NaN, since that has different timing that comparing two numbers.
+      match &= a.charCodeAt( i % aLen ) === b.charCodeAt( i % bLen ) ? 1 : 0;
+    }
+    return match === 1;
+  }
+}

--- a/credential.js
+++ b/credential.js
@@ -152,16 +152,15 @@ var crypto = require('crypto'),
    * @return {Boolean}
    */
   constantEquals = function constantEquals(x, y) {
-    var result = true,
-      length = (x.length > y.length) ? x.length : y.length,
-      i;
-
-    for (i=0; i<length; i++) {
-      if (x.charCodeAt(i) !== y.charCodeAt(i)) {
-        result = false;
-      }
+    var result = (x.length === y.length ? 0 : 1),
+      length = Math.max(x.length, y.length),
+      xc, yc, i;
+    for (i=0; i < length; i++) {
+      xc = x.charCodeAt(i);
+      yc = y.charCodeAt(i);
+      result |= xc ^ yc
     }
-    return result;
+    return result === 0;
   },
 
   parseHash = function parseHash(encodedHash) {
@@ -240,5 +239,6 @@ var crypto = require('crypto'),
 module.exports = mixIn({}, defaults, {
   hash: toHash,
   verify: verify,
-  configure: configure
+  configure: configure,
+  constantEquals: constantEquals
 });

--- a/credential.js
+++ b/credential.js
@@ -19,7 +19,7 @@
  * MIT license http://opensource.org/licenses/MIT
  */
 
-// 'use strict';
+'use strict';
 var crypto = require('crypto'),
   mixIn = require('mout/object/mixIn'),
   constantTimeCompare = require('./constantTimeCompare'),

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.2",
-    "tape": "~1.0.4"
+    "tape": "~1.0.4",
+    "ttest": "^0.3.0"
   },
   "scripts": {
     "test": "node test/credential-test.js"

--- a/test/credential-test.js
+++ b/test/credential-test.js
@@ -169,6 +169,11 @@ test('constantEquals', function (t) {
       difflen_results = 0;
   // Ensure it works
   t.ok(pw.constantEquals("abc", "abc"), 'equality')
+  t.ok(pw.constantEquals("", ""), 'equal-empty')
+  t.ok(!pw.constantEquals("a", ""), 'inequal 1-char')
+  t.ok(pw.constantEquals("a", "a"), 'equal 1-char')
+  t.ok(!pw.constantEquals("ab", "ac"), 'inequal 2-char')
+  t.ok(pw.constantEquals("ab", "ab"), 'equal 2-char')
   t.ok(!pw.constantEquals("abc", "abC"), 'inequality - difference')
   t.ok(!pw.constantEquals("abc", "abcD"), 'inequality - addition')
   t.ok(!pw.constantEquals("abc", "ab"), 'inequality - missing')
@@ -199,7 +204,7 @@ test('constantEquals', function (t) {
   t.ok(Math.abs((equal_results - inequal_results)/equal_results) < tolerance,
       "inequal and equal results within " + tolerance)
   t.ok(Math.abs((equal_results - difflen_results)/equal_results) < tolerance, 
-    "differing-lengths and equal results within " + tolerance)
+      "differing-lengths and equal results within " + tolerance)
   t.end()
 });
 

--- a/test/credential-test.js
+++ b/test/credential-test.js
@@ -157,26 +157,28 @@ test('verify with empty password', function(t) {
 });
 
 test('constantEquals', function (t) {
+  var ctc = require('../constantTimeCompare');
+
   function timed_compare(a, b) {
     var start = process.hrtime();
-    pw.constantEquals(a, b);
+    ctc(a, b);
     return process.hrtime(start)[1];
   }
   var i,
-      iterations = 25000,
+      iterations = 5000,
       equal_results = 0,
       inequal_results = 0,
       difflen_results = 0;
   // Ensure it works
-  t.ok(pw.constantEquals("abc", "abc"), 'equality')
-  t.ok(pw.constantEquals("", ""), 'equal-empty')
-  t.ok(!pw.constantEquals("a", ""), 'inequal 1-char')
-  t.ok(pw.constantEquals("a", "a"), 'equal 1-char')
-  t.ok(!pw.constantEquals("ab", "ac"), 'inequal 2-char')
-  t.ok(pw.constantEquals("ab", "ab"), 'equal 2-char')
-  t.ok(!pw.constantEquals("abc", "abC"), 'inequality - difference')
-  t.ok(!pw.constantEquals("abc", "abcD"), 'inequality - addition')
-  t.ok(!pw.constantEquals("abc", "ab"), 'inequality - missing')
+  t.ok(ctc("abc", "abc"), 'equality')
+  t.ok(ctc("", ""), 'equal empty')
+  t.ok(!ctc("a", ""), 'inequal 1-char')
+  t.ok(ctc("a", "a"), 'equal 1-char')
+  t.ok(!ctc("ab", "ac"), 'inequal 2-char')
+  t.ok(ctc("ab", "ab"), 'equal 2-char')
+  t.ok(!ctc("abc", "abC"), 'inequality - difference')
+  t.ok(!ctc("abc", "abcD"), 'inequality - addition')
+  t.ok(!ctc("abc", "ab"), 'inequality - missing')
 
   // Ensure timing is sane
   // Differing lengths

--- a/test/credential-test.js
+++ b/test/credential-test.js
@@ -163,6 +163,7 @@ test('constantEquals', function (t) {
     return process.hrtime(start)[1];
   }
   var i,
+      iterations = 25000,
       equal_results = 0,
       inequal_results = 0,
       difflen_results = 0;
@@ -174,19 +175,31 @@ test('constantEquals', function (t) {
 
   // Ensure timing is sane
   // Differing lengths
-  for (i = 0; i < 250; i++) {
+  for (i = 0; i < iterations; i++) {
     difflen_results += timed_compare("abcd", "abcdefghijklmnopqrstuvwxyz");
   }
 
-  for (i = 0; i < 250; i++) {
+  for (i = 0; i < iterations; i++) {
     equal_results   += timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz");
   }
 
-  for (i = 0; i < 250; i++) {
+  for (i = 0; i < iterations; i++) {
     inequal_results += timed_compare("abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
   }
 
-  console.log("E", equal_results, "IE", inequal_results, "DL", difflen_results)
+  // This is a point of some statistical importance. A tolerance of 
+  // 0.05 is not actually particularly useful; it must be combined
+  // with the time-per-iteration and number of iterations to ensure
+  // that there is no statistically significant difference that
+  // illuminates what's happening in the comparison.
+  // 
+  // So `tolerance` here is really just a placeholder until a more
+  // sensible statistically sound comparison can be teased out of this test.
+  var tolerance = 0.05;
+  t.ok(Math.abs((equal_results - inequal_results)/equal_results) < tolerance,
+      "inequal and equal results within " + tolerance)
+  t.ok(Math.abs((equal_results - difflen_results)/equal_results) < tolerance, 
+    "differing-lengths and equal results within " + tolerance)
   t.end()
 });
 

--- a/test/credential-test.js
+++ b/test/credential-test.js
@@ -156,6 +156,55 @@ test('verify with empty password', function(t) {
 
 });
 
+test('constantEquals', function (t) {
+  function timed_compare(a, b) {
+    var start = process.hrtime();
+    pw.constantEquals(a, b);
+    return process.hrtime(start)[1];
+  }
+  // Ensure it works
+  t.ok(pw.constantEquals("abc", "abc"), 'equality')
+  t.ok(!pw.constantEquals("abc", "abC"), 'inequality - difference')
+  t.ok(!pw.constantEquals("abc", "abcD"), 'inequality - addition')
+  t.ok(!pw.constantEquals("abc", "ab"), 'inequality - missing')
+
+  // We use these three as "preloaders"; it seems to be about 3x 
+  // before the system settles to reliable timings.
+  timed_compare("", "abcdefghijklmnopqrstuvwxyz");
+  timed_compare("", "abcdefghijklmnopqrstuvwxyz");
+  timed_compare("", "abcdefghijklmnopqrstuvwxyz");
+
+  // Ensure timing is sane
+  var durations = [
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len 
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal 
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
+    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
+    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len 
+  ];
+
+  var max = Math.max.apply(Math, durations);
+  var min = Math.min.apply(Math, durations);
+  var spread = max - min;
+  t.ok(spread < 50, spread + " < 50 nanoseconds spread")
+});
+
+
 test('overrides', function (t) {
   var workUnits = 60;
   var workKey = 463;

--- a/test/credential-test.js
+++ b/test/credential-test.js
@@ -162,46 +162,32 @@ test('constantEquals', function (t) {
     pw.constantEquals(a, b);
     return process.hrtime(start)[1];
   }
+  var i,
+      equal_results = 0,
+      inequal_results = 0,
+      difflen_results = 0;
   // Ensure it works
   t.ok(pw.constantEquals("abc", "abc"), 'equality')
   t.ok(!pw.constantEquals("abc", "abC"), 'inequality - difference')
   t.ok(!pw.constantEquals("abc", "abcD"), 'inequality - addition')
   t.ok(!pw.constantEquals("abc", "ab"), 'inequality - missing')
 
-  // We use these three as "preloaders"; it seems to be about 3x 
-  // before the system settles to reliable timings.
-  timed_compare("", "abcdefghijklmnopqrstuvwxyz");
-  timed_compare("", "abcdefghijklmnopqrstuvwxyz");
-  timed_compare("", "abcdefghijklmnopqrstuvwxyz");
-
   // Ensure timing is sane
-  var durations = [
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len 
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyZ"), // inequal, same len
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal 
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
-    timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"), // equal
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len
-    timed_compare("", "abcdefghijklmnopqrstuvwxyz"), // inequal, diff len 
-  ];
+  // Differing lengths
+  for (i = 0; i < 250; i++) {
+    difflen_results += timed_compare("abcd", "abcdefghijklmnopqrstuvwxyz");
+  }
 
-  var max = Math.max.apply(Math, durations);
-  var min = Math.min.apply(Math, durations);
-  var spread = max - min;
-  t.ok(spread < 50, spread + " < 50 nanoseconds spread")
+  for (i = 0; i < 250; i++) {
+    equal_results   += timed_compare("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz");
+  }
+
+  for (i = 0; i < 250; i++) {
+    inequal_results += timed_compare("abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  }
+
+  console.log("E", equal_results, "IE", inequal_results, "DL", difflen_results)
+  t.end()
 });
 
 


### PR DESCRIPTION
This is a variant of the canonical method for comparing strings in constant time, regarding issue #12 .

Note that one has to disable `use strict` to be able to use `with({})`, which one must employ to sidetrack V8 compiler optimizations that ruin the timing characteristics.

The unit testing of this PR is rudimentary and does not reveal statistical significance of timing variations.

Ideally the average deviation (excluding the occasional long run-time of the function) ought to vary by 25µs or so between equal, and inequal (of the same and different lengths) strings.

If this design, or a variant of it, is unable to achieve the desired timing characteristic then one would have to fundamentally reconsider how constant time string comparisons would occur in Javascript.