### PR TITLE
Fix deprecation warning and failing test under Node v6 (fixes #70)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "0.12"
   - "4"
   - "5"
+  - "6"
 install:
   - npm install
 script:

--- a/credential.js
+++ b/credential.js
@@ -59,7 +59,7 @@ var crypto = require('crypto'),
   pbkdf2 = function pbkdf2 (password, salt, iterations,
     keyLength, callback) {
     crypto.pbkdf2(password, salt,
-      iterations, keyLength, function (err, hash) {
+      iterations, keyLength, 'SHA1', function (err, hash) {
         if (err) {
           return callback(err);
         }
@@ -163,7 +163,7 @@ var crypto = require('crypto'),
 
     if (typeof (password) !== 'string' || password.length === 0) {
       return callback(new Error('Password must be a ' +
-        ' non-empty string.'));
+        'non-empty string.'));
     }
 
     // Create the salt
@@ -217,7 +217,7 @@ var crypto = require('crypto'),
         'hash.'));
     } else if (typeof (input) !== 'string' || input.length === 0) {
       return callback(new Error('Input password must ' +
-        ' be a non-empty string.'));
+        'be a non-empty string.'));
     }
 
     var n = storedHash.iterations;

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -92,9 +92,9 @@ test('cli - hash - no password', function (t){
     t.ifError(err);
 
     var actual = stderr.trim();
-    var expected = '[Error: Password must be a  non-empty string.]';
+    var expected = /Error: Password must be a non-empty string/;
 
-    t.is(actual, expected);
+    t.ok(expected.test(actual));
 
     t.end();
   });


### PR DESCRIPTION
Fixes two problems with credential under Node v6:

* crypto.pbkdf2 without an explicit digest algorithm has been deprecated
* The formatting of logging Error objects was changed by nodejs/node#4582

So:

* Node v6 is now tested by Travis
* "SHA1" (the old default) is now present as an explicit parameter
* A CLI test that was checking stderr with equality (and failing) now uses a regex