### PR TITLE
Fix #70, Use SHA1 digest with pbkdf2 method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "0.12"
   - "4"
   - "5"
+  - "6"
 install:
   - npm install
 script:

--- a/credential.js
+++ b/credential.js
@@ -59,7 +59,7 @@ var crypto = require('crypto'),
   pbkdf2 = function pbkdf2 (password, salt, iterations,
     keyLength, callback) {
     crypto.pbkdf2(password, salt,
-      iterations, keyLength, function (err, hash) {
+      iterations, keyLength, 'SHA1', function (err, hash) {
         if (err) {
           return callback(err);
         }
@@ -163,7 +163,7 @@ var crypto = require('crypto'),
 
     if (typeof (password) !== 'string' || password.length === 0) {
       return callback(new Error('Password must be a ' +
-        ' non-empty string.'));
+        'non-empty string.'));
     }
 
     // Create the salt
@@ -217,7 +217,7 @@ var crypto = require('crypto'),
         'hash.'));
     } else if (typeof (input) !== 'string' || input.length === 0) {
       return callback(new Error('Input password must ' +
-        ' be a non-empty string.'));
+        'be a non-empty string.'));
     }
 
     var n = storedHash.iterations;

--- a/credential.js
+++ b/credential.js
@@ -26,6 +26,7 @@ var crypto = require('crypto'),
   P = require('pinkie-promise'),
   constantTimeCompare = require('./constantTimeCompare'),
 
+  useDigest = process.versions.node.substr(0, 4) !== '0.10',
   msPerDay = 24 * 60 * 60 * 1000,
   msPerYear = 365.242199 * msPerDay,
   y2k = new Date(2000, 0, 1),
@@ -58,13 +59,19 @@ var crypto = require('crypto'),
    */
   pbkdf2 = function pbkdf2 (password, salt, iterations,
     keyLength, callback) {
-    crypto.pbkdf2(password, salt,
-      iterations, keyLength, 'SHA1', function (err, hash) {
-        if (err) {
-          return callback(err);
-        }
-        callback(null, hash.toString('base64'));
-      });
+    var argumentsList = [password, salt, iterations,
+      keyLength, 'SHA1', function (err, hash) {
+      if (err) {
+        return callback(err);
+      }
+      callback(null, hash.toString('base64'));
+    }];
+
+    if (!useDigest) {
+      argumentsList.splice(4, 1);
+    }
+
+    crypto.pbkdf2.apply(null, argumentsList);
   },
 
   hashMethods = {

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -91,11 +91,10 @@ test('cli - hash - no password', function (t){
   var stdin = execCli(['hash'], function (err, stdout, stderr){
     t.ifError(err);
 
+    var actual = stderr.trim();
     var expected = /Error: Password must be a non-empty string/;
 
-    t.throws(function (){
-      throw stderr;
-    }, expected, 'should throw non-empty string error');
+    t.ok(expected.test(actual));
 
     t.end();
   });

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -91,10 +91,11 @@ test('cli - hash - no password', function (t){
   var stdin = execCli(['hash'], function (err, stdout, stderr){
     t.ifError(err);
 
-    var actual = stderr.trim();
-    var expected = '[Error: Password must be a  non-empty string.]';
+    var expected = /Error: Password must be a non-empty string/;
 
-    t.is(actual, expected);
+    t.throws(function (){
+      throw stderr;
+    }, expected, 'should throw non-empty string error');
 
     t.end();
   });


### PR DESCRIPTION
Fixes #70 
Closes #71 

**Changelog**

- [x] Added `SHA1` digest for `pbkdf2`, will be ignored for `v0.10`
- [x] Fixed test to check non-empty error properly
- [x] Travis now run for `v6`

Essentially this would remove the deprecation warning in Node `v6`, but still remains a non breaking change because of version check.

cc @ericelliott @tjconcept @brianmhunt
