### PR TITLE
Add expired command

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -45,6 +45,18 @@ program
     });
   });
 
+program
+  .command('expired <hash> [days]')
+  .description('Verify hash expiration')
+  .action(function (hash, days){
+    var expired = credential().expired(stdin || hash, days)
+    if (expired) {
+      throw new Error('Expired');
+    } else {
+      console.log('Not expired')
+    }
+  });
+
 if (process.stdin.isTTY) {
   program.parse(process.argv);
 } else {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -49,11 +49,11 @@ program
   .command('expired <hash> [days]')
   .description('Verify hash expiration')
   .action(function (hash, days){
-    var expired = credential().expired(stdin || hash, days)
+    var expired = credential().expired(stdin || hash, days);
     if (expired) {
       throw new Error('Expired');
     } else {
-      console.log('Not expired')
+      console.log('Not expired');
     }
   });
 

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -142,6 +142,25 @@ test('cli - expired - stdin', function (t){
   });
 });
 
+test('cli - expired - without days argument', function (t){
+  credential().hash('password', function (err, hash){
+    t.ifError(err);
+
+    var stdin = execCli(['expired', hash], function (err, stdout){
+      t.ifError(err);
+
+      var actual = stdout.trim();
+      var expected = 'Not expired';
+
+      t.is(actual, expected);
+
+      t.end();
+    });
+
+    stdin.end();
+  });
+});
+
 var pseudoOldHash = '{"iterations": 0}';
 
 test('cli - expired - did expired', function (t){

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -101,3 +101,56 @@ test('cli - hash - no password', function (t){
 
   stdin.end();
 });
+
+test('cli - expired', function (t){
+  credential().hash('password', function (err, hash){
+    t.ifError(err);
+
+    var stdin = execCli(['expired', hash, 90], function (err, stdout){
+      t.ifError(err);
+
+      var actual = stdout.trim();
+      var expected = 'Not expired';
+
+      t.is(actual, expected);
+
+      t.end();
+    });
+
+    stdin.end();
+  });
+});
+
+test('cli - expired - stdin', function (t){
+
+  credential().hash('password', function (err, hash){
+    t.ifError(err);
+
+    var stdin = execCli(['expired', '-', 90], function (err, stdout){
+      t.ifError(err);
+
+      var actual = stdout.trim();
+      var expected = 'Not expired';
+
+      t.is(actual, expected);
+
+      t.end();
+    });
+
+    stdin.write(hash);
+    stdin.end();
+  });
+});
+
+var pseudoOldHash = '{"iterations": 0}';
+
+test('cli - expired - did expired', function (t){
+  var stdin = execCli(['expired', pseudoOldHash, 0], function (err, stdout, stderr){
+    var actual = stderr.trim();
+    var expected = /Error: Expired/;
+    t.ok(expected.test(actual));
+    t.end();
+  });
+
+  stdin.end();
+});


### PR DESCRIPTION
Give access to `credential expired` so that available commands match the functions exposed by the module.

`credential expired [hash] <password>` will throw when the password expired to match `credential verify` behavior
